### PR TITLE
Fix check end of paging

### DIFF
--- a/sonarcloud/paging/paging.go
+++ b/sonarcloud/paging/paging.go
@@ -15,5 +15,5 @@ type Paging struct {
 
 // End returns whether the last page has been reached or not
 func (p *Paging) End() bool {
-	return float64(p.PageIndex) >= float64(p.Total)/float64(p.PageSize)
+	return p.PageIndex * p.PageSize >= p.Total
 }

--- a/sonarcloud/paging/paging.go
+++ b/sonarcloud/paging/paging.go
@@ -15,5 +15,5 @@ type Paging struct {
 
 // End returns whether the last page has been reached or not
 func (p *Paging) End() bool {
-	return p.PageIndex >= p.Total/p.PageSize
+	return float64(p.PageIndex) >= float64(p.Total)/float64(p.PageSize)
 }


### PR DESCRIPTION
When checking if a page is the last page or not, there is a bug. In Golang, when you divide integers, the result is truncated to integer (omitting the rest). You can see an example of bad behaviour here: https://go.dev/play/p/azXCyGPLddI

In order to fix this function, it should cast the elements to `float64`. An example of the behaviour of the new function can be found here https://go.dev/play/p/mGM8tvu65VJ